### PR TITLE
Update rootMargin propType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default class Visible extends Component
     onHide      : PropTypes.func,
     options     : PropTypes.shape( {
       root       : PropTypes.node,
-      rootMargin : PropTypes.number,
+      rootMargin : PropTypes.string,
       threshold  : PropTypes.oneOfType( PropTypes.number, PropTypes.array ),
     } ),
   };


### PR DESCRIPTION
According to https://wicg.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin the `rootMargin` property is a string with any of this forms 

```
"5px"                
"5px 10px"      
"-10px 5px 8px"   
"-10px -5px 5px 8px"
```