### PR TITLE
Fix rootMargin propType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default class IntersectionVisible extends Component {
       /**
        * Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left). The values can be percentages. This set of values serves to grow or shrink each side of the root element's bounding box before computing intersections. Defaults to all zeros.
       */
-      rootMargin: PropTypes.number,
+      rootMargin: PropTypes.string,
       /**
        * Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback run every time visibility passes another 25%, you would specify the array [0, 0.25, 0.5, 0.75, 1]. The default is 0 (meaning as soon as even one pixel is visible, the callback will be run). A value of 1.0 means that the threshold isn't considered passed until every pixel is visible.
       */


### PR DESCRIPTION
This fixes #20.

Indeed according to [W3C documentation](https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin), `rootMargin` is of `string` type.

